### PR TITLE
XML string parsing and document ID extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ list of dictionary output.
 - `extract_funding`
 - `extract_conferences`
 - `extract_references`
+- `extract_identifiers`
 
 ## Installation
 

--- a/wos_parser/parser.py
+++ b/wos_parser/parser.py
@@ -1,10 +1,10 @@
 from lxml import etree
 
 # For compatibility with Py2.7
-    try:
-        from io import StringIO
-    except ImportError:
-        from StringIO import StringIO
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
 
 def get_record(filehandle):
     """Iteratively go through file and get text of each WoS record"""

--- a/wos_parser/parser.py
+++ b/wos_parser/parser.py
@@ -352,7 +352,7 @@ def extract_identifiers(elem):
 
     Returns
     ==========
-    dict {identifier type: value}, e.g. identifier types may be DOI, ISSN, etc.
+    dict {identifier type: value} or empty dict if none found. Identifier types may be DOI, ISSN, etc.
     """
     idents = elem.findall('./dynamic_data/cluster_related/identifiers')
     id_dict = {}

--- a/wos_parser/parser.py
+++ b/wos_parser/parser.py
@@ -243,6 +243,11 @@ def extract_pub_info(elem):
     pub_info_dict.update({'keywords': keywords,
                           'keywords_plus': keywords_plus})
 
+    identifiers = extract_identifiers(elem)
+    for k, v in identifiers.items():
+        pub_info_dict.update({k: v})
+    # End for
+
     return pub_info_dict
 
 def extract_funding(elem):
@@ -337,3 +342,23 @@ def extract_references(elem):
         ref_dict.update({'wos_id': wos_id})
         ref_list.append(ref_dict)
     return ref_list
+
+def extract_identifiers(elem):
+    """Extract document identifiers from WoS element tree
+
+    Parameters
+    ==========
+    elem: etree.Element object, WoS element
+
+    Returns
+    ==========
+    dict {identifier type: value}, e.g. identifier types may be DOI, ISSN, etc.
+    """
+    idents = elem.findall('./dynamic_data/cluster_related/identifiers')
+    id_dict = {}
+    for ident in idents:
+        for child in ident.getchildren():
+            id_dict.update({child.get('type'): child.get('value')})
+    # End for
+
+    return id_dict


### PR DESCRIPTION
@titipata thanks for your work on this package, saved me a ton of time.

I'm using the [wos package](https://github.com/enricobacis/wos) which can get the XML response but I didn't want to write these out to a file. So I've added the ability to parse WoS XML directly from the string.

Use like:

`wos_parser.read_xml_string(xml_string)`

I've also added document identifier extraction (DOI, ISSN, etc) as I want these as part of the publication information as well.

`identifiers = wos_parser.extract_identifiers(record)`

The `readme` file has also been updated to list this new function.

I know it's poor form to mix changes like this together but they're small and in separate commits so they should be straightforward to review.

Thanks again!